### PR TITLE
Fix WaitForSingleObject error checks

### DIFF
--- a/AutoPatchLoader/Injector.cs
+++ b/AutoPatchLoader/Injector.cs
@@ -122,8 +122,7 @@ namespace AutoPatchLoader
                                     uint Result = WaitForSingleObject(hThread, 10 * 1000);
 
                                     //...
-                                    if (Result != WAIT_FAILED || Result != WAIT_ABANDONED
-                                       || Result != WAIT_OBJECT_0 || Result != WAIT_TIMEOUT)
+                                    if (Result != WAIT_FAILED && Result != WAIT_ABANDONED && Result != WAIT_TIMEOUT)
                                     {
                                         //on désalloc la mémoire allouée
                                         if (VirtualFreeEx(hProcess, hModule, 0, MEM_RELEASE))

--- a/AutoUpdater/Injector.cs
+++ b/AutoUpdater/Injector.cs
@@ -85,8 +85,7 @@ namespace AutoUpdater
                                     uint Result = WaitForSingleObject(hThread, 10 * 1000);
 
                                     //...
-                                    if (Result != WAIT_FAILED || Result != WAIT_ABANDONED
-                                                              || Result != WAIT_OBJECT_0 || Result != WAIT_TIMEOUT)
+                                    if (Result != WAIT_FAILED && Result != WAIT_ABANDONED && Result != WAIT_TIMEOUT)
                                     {
                                         //on désalloc la mémoire allouée
                                         if (VirtualFreeEx(hProcess, hModule, 0, MEM_RELEASE))


### PR DESCRIPTION
Fix error checks for the injector that resulted in the checks always succeeding.